### PR TITLE
Create circle.yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,6 @@
+dependencies:
+  pre:
+  - sudo apt-get -y -qq install libgles2-mesa-dev libegl1-mesa-drivers libgl1-mesa-dri
+test:
+  override:
+  - echo "Hello Circle!"


### PR DESCRIPTION
Added circle.yml.

Once Circle CI has been configured to run this project, it will fail until this file can be found in the repository, so this version of the file can be merged in its empty form just to make the build message shut up until we've figured out how to make it actually do something interesting.
